### PR TITLE
Allow running a non-local skill

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,5 +10,6 @@
         <Version>$(SemVersion).0</Version>
         <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
         <AnalysisMode>AllEnabledByDefault</AnalysisMode>
+        <WarningsAsErrors>true</WarningsAsErrors>
     </PropertyGroup>
 </Project>

--- a/src/Abbot.CommandLine/AbbotApi.cs
+++ b/src/Abbot.CommandLine/AbbotApi.cs
@@ -2,40 +2,17 @@ using System;
 using System.Net;
 using System.Threading.Tasks;
 using Refit;
-using Serious.Abbot.CommandLine.Commands;
-using Serious.Abbot.CommandLine.Services;
 
 namespace Serious.Abbot.CommandLine
 {
     public static class AbbotApi
     {
-#if DEBUG
-        const string ApiHost = "https://localhost:4979/";
-#else
-        const string ApiHost = "https://api.ab.bot/";
-#endif
-
-        public static IAbbotApi CreateInstance(Workspace workspace)
-        {
-            var settings = new RefitSettings
-            {
-                AuthorizationHeaderValueGetter = async () => await workspace.GetTokenAsync() ?? string.Empty,
-            };
-#pragma warning disable CA2000
-            var httpClient = RestService.CreateHttpClient(ApiHost, settings);
-#pragma warning restore CA2000
-            var version = StatusCommand.GetVersion();
-            httpClient.DefaultRequestHeaders.Add("X-Client-Version", version);
-            httpClient.DefaultRequestHeaders.Add("User-Agent", $"abbot-cli ({version})");
-            return RestService.For<IAbbotApi>(httpClient);
-        }
-
         /// <summary>
         /// If the response status is not successful, then this examines the response and writes an appropriate
         /// error message to the console.
         /// </summary>
         /// <param name="response">The response</param>
-        /// <typeparam name="T"></typeparam>
+        /// <typeparam name="T">The response body type</typeparam>
         /// <returns>The error code to return.</returns>
         public static async Task<int> HandleUnsuccessfulResponseAsync<T>(this ApiResponse<T> response)
         {

--- a/src/Abbot.CommandLine/CommandContext.cs
+++ b/src/Abbot.CommandLine/CommandContext.cs
@@ -1,0 +1,48 @@
+using Serious.Abbot.CommandLine.IO;
+using Serious.Abbot.CommandLine.Services;
+
+namespace Serious.Abbot.CommandLine
+{
+    /// <summary>
+    /// Context useful for each invocation.
+    /// </summary>
+    public class CommandContext : ICommandContext
+    {
+        readonly IWorkspaceFactory _workspaceFactory;
+        readonly IApiClientFactory _apiClientFactory;
+
+        public CommandContext() : this(new ExtendedSystemConsole(), new WorkspaceFactory(), new ApiClientFactory())
+        {
+        }
+
+        public CommandContext(
+            IExtendedConsole console,
+            IWorkspaceFactory workspaceFactory,
+            IApiClientFactory apiClientFactory)
+        {
+            _workspaceFactory = workspaceFactory;
+            _apiClientFactory = apiClientFactory;
+            Console = console;
+        }
+
+        /// <summary>
+        /// The Console to write to.
+        /// </summary>
+        public IExtendedConsole Console { get; }
+        
+        /// <summary>
+        /// Creates an Abbot API client using the token stored in the <see cref="Workspace" />.
+        /// </summary>
+        /// <param name="workspace">The workspace to use for the API client.</param>
+        /// <returns>An <see cref="IAbbotApi"/> instance.</returns>
+        public IAbbotApi CreateApiClient(Workspace workspace) => _apiClientFactory.Create(workspace);
+
+        /// <summary>
+        /// Creates an instance of a <see cref="Workspace"/> pointing to the specified directory.
+        /// Note that this doesn't create the actual workspace on disk. <see cref="Workspace.EnsureAsync"/> has to be
+        /// called on the <see cref="Workspace"/> instance to create the workspace on disk.
+        /// </summary>
+        /// <param name="directory">Path to the Abbot workspace directory.</param>
+        public Workspace GetWorkspace(string? directory) => _workspaceFactory.GetWorkspace(directory);
+    }
+}

--- a/src/Abbot.CommandLine/Commands/AbbotCommand.cs
+++ b/src/Abbot.CommandLine/Commands/AbbotCommand.cs
@@ -1,0 +1,45 @@
+using System.CommandLine;
+using System.CommandLine.IO;
+using Serious.Abbot.CommandLine.IO;
+using Serious.Abbot.CommandLine.Services;
+
+namespace Serious.Abbot.CommandLine.Commands
+{
+    public abstract class AbbotCommand : Command
+    {
+        readonly ICommandContext _commandContext;
+
+        protected AbbotCommand(ICommandContext commandContext, string name, string? description = null)
+            : base(name, description)
+        {
+            _commandContext = commandContext;
+            Console = commandContext.Console;
+        }
+
+        /// <summary>
+        /// Creates an instance of a <see cref="Workspace"/> pointing to the specified directory.
+        /// Note that this doesn't create the actual workspace on disk. <see cref="Workspace.EnsureAsync"/> has to be
+        /// called on the <see cref="Workspace"/> instance to create the workspace on disk.
+        /// </summary>
+        /// <param name="directory">Path to the Abbot workspace directory.</param>
+        protected Workspace GetWorkspace(string? directory) => _commandContext.GetWorkspace(directory);
+
+        /// <summary>
+        /// Creates the Abbot API client using the API token stored in the workspace.
+        /// </summary>
+        /// <param name="workspace">The workspace</param>
+        protected IAbbotApi CreateApiClient(Workspace workspace) => _commandContext.CreateApiClient(workspace);
+
+        /// <summary>
+        /// The Console to write to.
+        /// </summary>
+        protected IExtendedConsole Console { get; }
+
+        protected int HandleUninitializedWorkspace(Workspace workspace)
+        {
+            var directoryType = workspace.DirectorySpecified ? "specified" : "current";
+            Console.Error.WriteLine($"The {directoryType} directory is not an Abbot Workspace. Either specify the path to an Abbot Workspace, or initialize a new one using `abbot init`");
+            return 1;
+        }
+    }
+}

--- a/src/Abbot.CommandLine/Commands/AuthCommand.cs
+++ b/src/Abbot.CommandLine/Commands/AuthCommand.cs
@@ -1,21 +1,17 @@
-using System;
-using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Threading.Tasks;
-using Serious.Abbot.CommandLine.Services;
+using Serious.Abbot.CommandLine.IO;
 
 namespace Serious.Abbot.CommandLine.Commands
 {
-    public class AuthCommand : Command
+    public class AuthCommand : AbbotCommand
     {
-        readonly IWorkspaceFactory _workspaceFactory;
         const string TokenPage = $"{Program.Website}/account/apikeys";
 
-        public AuthCommand(IWorkspaceFactory workspaceFactory)
-            : base("auth", "Authenticate the abbot command line")
+        public AuthCommand(ICommandContext commandContext)
+            : base(commandContext, "auth", "Authenticate the abbot command line")
         {
-            _workspaceFactory = workspaceFactory;
             this.AddDirectoryOption();
             this.AddOption<string>("--token", "-t", $"The API Key token created at {TokenPage}.");
 
@@ -27,7 +23,7 @@ namespace Serious.Abbot.CommandLine.Commands
         /// </summary>
         async Task<int> HandleAuthenticateCommandAsync(string? directory, string token)
         {
-            var workspace = _workspaceFactory.GetWorkspace(directory);
+            var workspace = GetWorkspace(directory);
             await workspace.EnsureAsync();
             
             if (token is { Length: > 0 })
@@ -36,7 +32,7 @@ namespace Serious.Abbot.CommandLine.Commands
                 return 0;
             }
 
-            Console.WriteLine(Messages.Auth_Message, TokenPage);
+            Console.Out.WriteLine(Messages.Auth_Message, TokenPage);
             
             var psi = new ProcessStartInfo
             {
@@ -45,7 +41,7 @@ namespace Serious.Abbot.CommandLine.Commands
             };
             Process.Start(psi);
 
-            Console.Write("Type in the API Key token and hit ENTER: ");
+            Console.Out.Write("Type in the API Key token and hit ENTER: ");
             var readToken = Console.ReadLine();
             if (readToken is { Length: > 0 })
             {

--- a/src/Abbot.CommandLine/Commands/InitCommand.cs
+++ b/src/Abbot.CommandLine/Commands/InitCommand.cs
@@ -1,29 +1,24 @@
-using System;
-using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Threading.Tasks;
-using Serious.Abbot.CommandLine.Services;
+using Serious.Abbot.CommandLine.IO;
 
 namespace Serious.Abbot.CommandLine.Commands
 {
-    public class InitCommand : Command
+    public class InitCommand : AbbotCommand
     {
-        readonly IWorkspaceFactory _workspaceFactory;
-
-        public InitCommand(IWorkspaceFactory workspaceFactory)
-            : base("init", "Set up a directory as an Abbot Workspace")
+        public InitCommand(ICommandContext commandContext)
+            : base(commandContext, "init", "Set up a directory as an Abbot Workspace")
         {
-            _workspaceFactory = workspaceFactory;
             this.AddDirectoryOption();
             Handler = CommandHandler.Create<string?>(HandleInitCommandAsync);
         }
 
         async Task<int> HandleInitCommandAsync(string? directory)
         {
-            var workspace = _workspaceFactory.GetWorkspace(directory);
+            var workspace = GetWorkspace(directory);
             await workspace.EnsureAsync();
 
-            Console.WriteLine(Messages.Initialized_Abbot_Directory, workspace.WorkingDirectory);
+            Console.Out.WriteLine(Messages.Initialized_Abbot_Directory, workspace.WorkingDirectory);
             return 0;
         }
     }

--- a/src/Abbot.CommandLine/Commands/RunCommand.cs
+++ b/src/Abbot.CommandLine/Commands/RunCommand.cs
@@ -1,41 +1,64 @@
-using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.CommandLine.IO;
 using System.Threading.Tasks;
 using Serious.Abbot.CommandLine.Services;
 using Serious.Abbot.Messages;
 
 namespace Serious.Abbot.CommandLine.Commands
 {
-    public class RunCommand : Command
+    public class RunCommand : AbbotCommand
     {
-        readonly IWorkspaceFactory _workspaceFactory;
-
-        public RunCommand(IWorkspaceFactory workspaceFactory)
-            : base("run", "Runs your skill code in the skill runner")
+        public RunCommand(ICommandContext commandContext)
+            : base(commandContext, "run", "Runs your skill code in the skill runner")
         {
-            _workspaceFactory = workspaceFactory;
             Add(new Argument<string>("skill", () => string.Empty, "The name of the skill to run"));
             Add(new Argument<string>("arguments", () => ".", "The arguments to pass to the skill"));
             this.AddDirectoryOption();
+            this.AddOption<bool>("--deployed", "-s", "If specified, runs the deployed version of the skill. Aka, the version on the server.");
 
-            Handler = CommandHandler.Create<string, string, string?>(HandleRunCommandAsync);
+            Handler = CommandHandler.Create<string, string, string?, bool>(HandleRunCommandAsync);
         }
 
-        internal async Task<int> HandleRunCommandAsync(string skill, string arguments, string? directory)
+        internal async Task<string?> GetCodeToRunAsync(string skill, Workspace workspace, bool deployed)
         {
-            var workspace = _workspaceFactory.GetWorkspace(directory);
-            var skillWorkspace = workspace.GetSkillWorkspace(skill);
-
-            var codeResult = await skillWorkspace.GetCodeAsync(workspace);
-            if (!codeResult.IsSuccess)
+            if (deployed)
             {
-                await Console.Error.WriteLineAsync(codeResult.ErrorMessage);
-                return 1;
+                return string.Empty;
             }
             
-            var code = codeResult.Code!;
+            var skillWorkspace = workspace.GetSkillWorkspace(skill);
 
+            var codeResult = await skillWorkspace.GetCodeAsync();
+            if (!codeResult.IsSuccess)
+            {
+                Console.Error.WriteLine(codeResult.ErrorMessage ?? "Unknown error occurred");
+                return null;
+            }
+            
+            return codeResult.Code!;
+        }
+
+        async Task<int> HandleRunCommandAsync(string skill, string arguments, string? directory, bool deployed)
+        {
+            var workspace = GetWorkspace(directory);
+            
+            if (!workspace.IsInitialized)
+            {
+                return HandleUninitializedWorkspace(workspace);
+            }
+
+            var code = await GetCodeToRunAsync(skill, workspace, deployed);
+            if (code is null)
+            {
+                return 1;
+            }
+
+            return await RunCodeAsync(skill, arguments, code, workspace, deployed);
+        }
+
+        internal async Task<int> RunCodeAsync(string skill, string arguments, string code, Workspace workspace, bool deployed)
+        {
             var runRequest = new SkillRunRequest
             {
                 Code = code,
@@ -43,8 +66,11 @@ namespace Serious.Abbot.CommandLine.Commands
                 Name = skill
             };
 
-            var response = await AbbotApi.CreateInstance(workspace)
-                .RunSkillAsync(skill, runRequest);
+            var client = CreateApiClient(workspace);
+            
+            var response = await (deployed
+                ? client.RunDeployedSkillAsync(skill, runRequest)
+                : client.RunSkillAsync(skill, runRequest));
             
             if (!response.IsSuccessStatusCode)
             {
@@ -53,11 +79,11 @@ namespace Serious.Abbot.CommandLine.Commands
 
             if (response.Content?.Replies is null)
             {
-                await Console.Error.WriteLineAsync("Response content is null");
+                Console.Error.WriteLine("Response content is null");
                 return 1;
             }
 
-            Console.WriteLine(string.Join("\n", response.Content.Replies));
+            Console.Out.WriteLine(string.Join("\n", response.Content.Replies));
             return 0;
         }
     }

--- a/src/Abbot.CommandLine/Commands/StatusCommand.cs
+++ b/src/Abbot.CommandLine/Commands/StatusCommand.cs
@@ -1,19 +1,15 @@
-using System;
-using System.CommandLine;
 using System.CommandLine.Invocation;
+using System.CommandLine.IO;
 using System.Threading.Tasks;
-using Serious.Abbot.CommandLine.Services;
+using Serious.Abbot.CommandLine.IO;
 
 namespace Serious.Abbot.CommandLine.Commands
 {
-    public class StatusCommand : Command
+    public class StatusCommand : AbbotCommand
     {
-        readonly IWorkspaceFactory _workspaceFactory;
-
-        public StatusCommand(IWorkspaceFactory workspaceFactory)
-            : base("status", "Get the status of the Abbot Workspace.")
+        public StatusCommand(ICommandContext commandContext)
+            : base(commandContext, "status", "Get the status of the Abbot Workspace.")
         {
-            _workspaceFactory = workspaceFactory;
             this.AddDirectoryOption();
             Handler = CommandHandler.Create<string?>(HandleStatusCommandAsync);
         }
@@ -25,13 +21,13 @@ namespace Serious.Abbot.CommandLine.Commands
 
         async Task<int> HandleStatusCommandAsync(string? directory)
         {
-            Console.WriteLine($"Running abbot-cli version {GetVersion()}");
-            var workspace = _workspaceFactory.GetWorkspace(directory);
+            Console.Out.WriteLine($"Running abbot-cli version {GetVersion()}");
+            var workspace = GetWorkspace(directory);
             var workingDir = workspace.WorkingDirectory.FullName;
             
             if (!workspace.WorkingDirectory.Exists)
             {
-                Console.WriteLine(Messages.Directory_Does_Not_Exist, workingDir);
+                Console.Out.WriteLine(Messages.Directory_Does_Not_Exist, workingDir);
                 return 0;
             }
 
@@ -39,18 +35,18 @@ namespace Serious.Abbot.CommandLine.Commands
             {
                 var initDirectory = !workspace.DirectorySpecified
                     ? ""
-                    : $" --directory {directory}";
-                Console.WriteLine(Messages.Directory_Is_Not_Abbot_Development_Enviroment, workingDir, initDirectory);
+                    : $" --directory {directory!}";
+                Console.Out.WriteLine(Messages.Directory_Is_Not_Abbot_Development_Enviroment, workingDir, initDirectory);
                 return 0;
             }
 
             if (!workspace.IsAuthenticated)
             {
-                Console.WriteLine(Messages.Abbot_Directory_Not_Authenticated, workingDir, directory);
+                Console.Out.WriteLine(Messages.Abbot_Directory_Not_Authenticated, workingDir, directory ?? ".");
                 return 0;
             }
 
-            var response = await AbbotApi.CreateInstance(workspace).GetStatusAsync();
+            var response = await CreateApiClient(workspace).GetStatusAsync();
             if (!response.IsSuccessStatusCode)
             {
                 if (!response.IsSuccessStatusCode)
@@ -61,7 +57,7 @@ namespace Serious.Abbot.CommandLine.Commands
 
             if (response.Content is null)
             {
-                await Console.Error.WriteLineAsync("No response from Abbot.");
+                Console.Error.WriteLine("No response from Abbot.");
                 return 1;
             }
 
@@ -71,7 +67,7 @@ namespace Serious.Abbot.CommandLine.Commands
             var status = @$"The directory {workingDir} is an authenticated Workspace.
 Organization: {organization.Name} ({organization.Platform} {organization.PlatformId})
 User: {user.Name} ({user.PlatformUserId})";
-            Console.WriteLine(status);
+            Console.Out.WriteLine(status);
             return 0;
         }
     }

--- a/src/Abbot.CommandLine/IAbbotApi.cs
+++ b/src/Abbot.CommandLine/IAbbotApi.cs
@@ -1,26 +1,64 @@
-using System.Net.Http;
 using System.Threading.Tasks;
 using Refit;
 using Serious.Abbot.Messages;
 
 namespace Serious.Abbot.CommandLine
 {
+    /// <summary>
+    /// Client to the Abbot API. Instances of this interface are created using Refit.
+    /// </summary>
     [Headers("Authorization: Bearer ")]
     public interface IAbbotApi
     {
+        /// <summary>
+        /// Retrieve information about a skill hosted on https://ab.bot/
+        /// </summary>
+        /// <param name="skill">The name of the skill to retrieve.</param>
         [Get("/api/cli/{skill}")]
         Task<ApiResponse<SkillGetResponse>> GetSkillAsync(string skill);
         
+        /// <summary>
+        /// Get the status of an Abbot Workspace such as whether it's authenticated, and to which org and user
+        /// it's authenticated.
+        /// </summary>
         [Get("/api/cli/status")]
         Task<ApiResponse<StatusGetResponse>> GetStatusAsync();
 
+        /// <summary>
+        /// Deploys local changes to a skill to https://ab.bot/
+        /// </summary>
+        /// <param name="skill">The name of the skill to deploy.</param>
+        /// <param name="updateRequest">Information about the code to deploy.</param>
         [Put("/api/cli/{skill}")]
         Task<ApiResponse<SkillUpdateResponse>> DeploySkillAsync(string skill, SkillUpdateRequest updateRequest);
 
+        /// <summary>
+        /// Runs the local version of a skill in the Abbot Skill Runner.
+        /// </summary>
+        /// <param name="skill">The name of the skill to run.</param>
+        /// <param name="runRequest">Information about the skill to run.</param>
         [Post("/api/cli/{skill}/run")]
         Task<ApiResponse<SkillRunResponse>> RunSkillAsync(string skill, SkillRunRequest runRequest);
+        
+        /// <summary>
+        /// Runs the deployed version of a skill in the Abbot Skill Runner, regardless of what is stored locally
+        /// for that skill.
+        /// </summary>
+        /// <param name="skill">The name of the skill to run.</param>
+        /// <param name="runRequest">Information about the skill to run.</param>
+        [Post("/api/cli/{skill}/deployed/run")]
+        Task<ApiResponse<SkillRunResponse>> RunDeployedSkillAsync(string skill, SkillRunRequest runRequest);
 
+        /// <summary>
+        /// List all the skills on https://ab.bot/ for the organization.
+        /// </summary>
+        /// <param name="orderBy">How to order the skills.</param>
+        /// <param name="direction">Which direction to order the skills.</param>
+        /// <param name="includeDisable">Whether to include disabled skills or not.</param>
         [Get("/api/cli/list")]
-        Task<ApiResponse<SkillListResponse>> ListSkillsAsync(SkillOrderBy orderBy, OrderDirection direction, bool includeDisable = false);
+        Task<ApiResponse<SkillListResponse>> ListSkillsAsync(
+            SkillOrderBy orderBy,
+            OrderDirection direction,
+            bool includeDisable = false);
     }
 }

--- a/src/Abbot.CommandLine/ICommandContext.cs
+++ b/src/Abbot.CommandLine/ICommandContext.cs
@@ -1,0 +1,31 @@
+using Serious.Abbot.CommandLine.IO;
+using Serious.Abbot.CommandLine.Services;
+
+namespace Serious.Abbot.CommandLine
+{
+    /// <summary>
+    /// Context useful for each invocation.
+    /// </summary>
+    public interface ICommandContext
+    {
+        /// <summary>
+        /// The Console to write to.
+        /// </summary>
+        IExtendedConsole Console { get; }
+
+        /// <summary>
+        /// Creates an Abbot API client using the token stored in the <see cref="Workspace" />.
+        /// </summary>
+        /// <param name="workspace">The workspace to use for the API client.</param>
+        /// <returns>An <see cref="IAbbotApi"/> instance.</returns>
+        IAbbotApi CreateApiClient(Workspace workspace);
+        
+        /// <summary>
+        /// Creates an instance of a <see cref="Workspace"/> pointing to the specified directory.
+        /// Note that this doesn't create the actual workspace on disk. <see cref="Workspace.EnsureAsync"/> has to be
+        /// called on the <see cref="Workspace"/> instance to create the workspace on disk.
+        /// </summary>
+        /// <param name="directory">Path to the Abbot workspace directory.</param>
+        Workspace GetWorkspace(string? directory);
+    }
+}

--- a/src/Abbot.CommandLine/IO/ConsoleExtensions.cs
+++ b/src/Abbot.CommandLine/IO/ConsoleExtensions.cs
@@ -1,0 +1,18 @@
+using System.CommandLine.IO;
+using System.Globalization;
+
+namespace Serious.Abbot.CommandLine.IO
+{
+    public static class StreamWriterExtensions
+    {
+        public static void WriteLine(this IStandardStreamWriter writer, string message, object arg)
+        {
+            writer.WriteLine(string.Format(CultureInfo.InvariantCulture, message, arg));
+        }
+        
+        public static void WriteLine(this IStandardStreamWriter writer, string message, object arg1, object arg2)
+        {
+            writer.WriteLine(string.Format(CultureInfo.InvariantCulture, message, arg1, arg2));
+        }
+    }
+}

--- a/src/Abbot.CommandLine/IO/ExtendedSystemConsole.cs
+++ b/src/Abbot.CommandLine/IO/ExtendedSystemConsole.cs
@@ -1,0 +1,38 @@
+using System;
+using System.CommandLine.IO;
+
+namespace Serious.Abbot.CommandLine.IO
+{
+    /// <summary>
+    /// Extends <see cref="SystemConsole" /> with methods to read from the standard input stream.
+    /// </summary>
+    public class ExtendedSystemConsole : SystemConsole, IExtendedConsole
+    {
+        /// <summary>
+        /// Clears the console buffer and corresponding console window of display information.
+        /// </summary>
+        public void Clear() => Console.Clear();
+
+        /// <summary>
+        /// Reads the next line of characters from the standard input stream.
+        /// </summary>
+        public string? ReadLine() => Console.ReadLine();
+
+        /// <summary>
+        /// Reads the next key from the input stream.
+        /// </summary>
+        public int Read() => Console.Read();
+
+        /// <summary>
+        /// Obtains the next character or function key pressed by the user.
+        /// The pressed key is displayed in the console window.
+        /// </summary>
+        public ConsoleKeyInfo ReadKey() => Console.ReadKey();
+        
+        /// <summary>
+        /// Obtains the next character or function key pressed by the user.
+        /// The pressed key is optionally displayed in the console window.
+        /// </summary>
+        public ConsoleKeyInfo ReadKey(bool intercept) => Console.ReadKey(intercept);
+    }
+}

--- a/src/Abbot.CommandLine/IO/IExtendedConsole.cs
+++ b/src/Abbot.CommandLine/IO/IExtendedConsole.cs
@@ -1,0 +1,38 @@
+using System;
+using System.CommandLine;
+
+namespace Serious.Abbot.CommandLine.IO
+{
+    /// <summary>
+    /// Adds Read methods to <see cref="IConsole"/>.
+    /// </summary>
+    public interface IExtendedConsole : IConsole
+    {
+        /// <summary>
+        /// Clears the console buffer and corresponding console window of display information.
+        /// </summary>
+        void Clear();
+        
+        /// <summary>
+        /// Reads the next line of characters from the standard input stream.
+        /// </summary>
+        string? ReadLine();
+
+        /// <summary>
+        /// Reads the next key from the input stream.
+        /// </summary>
+        int Read();
+
+        /// <summary>
+        /// Obtains the next character or function key pressed by the user.
+        /// The pressed key is displayed in the console window.
+        /// </summary>
+        ConsoleKeyInfo ReadKey();
+        
+        /// <summary>
+        /// Obtains the next character or function key pressed by the user.
+        /// The pressed key is optionally displayed in the console window.
+        /// </summary>
+        ConsoleKeyInfo ReadKey(bool intercept);
+    }
+}

--- a/src/Abbot.CommandLine/Program.cs
+++ b/src/Abbot.CommandLine/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.CommandLine;
+using System.CommandLine.IO;
 using System.Resources;
 using Serious.Abbot.CommandLine.Commands;
 using Serious.Abbot.CommandLine.Services;
@@ -15,27 +16,27 @@ namespace Serious.Abbot.CommandLine
 #else
         internal const string Website = "https://ab.bot";
 #endif
-        
+
         /// <summary>
         /// The main entry point
         /// </summary>
         /// <param name="args">The array of commandline arguments.</param>
         /// <returns>0 on success, an exit code on failure.</returns>
-        static int Main(string[] args)
+        public static int Main(string[] args)
         {
-            var factory = new WorkspaceFactory();
-            var runCommand = new RunCommand(factory);
+            var context = new CommandContext();
+            var runCommand = new RunCommand(context);
             // Create a root command with some options
             var rootCommand = new RootCommand
             {
-                new AuthCommand(factory),
-                new GetCommand(factory),
-                new InitCommand(factory),
-                new DeployCommand(factory),
-                new ListCommand(factory),
-                new ReplCommand(runCommand),
+                new AuthCommand(context),
+                new GetCommand(context),
+                new InitCommand(context),
+                new DeployCommand(context),
+                new ListCommand(context),
+                new ReplCommand(context, runCommand),
                 runCommand,
-                new StatusCommand(factory)
+                new StatusCommand(context)
             };
 
             rootCommand.Description = "Abbot command line. Use this to set up a local Abbot Workspace. To get started, run `abbot auth` in a directory where you want to edit skills.";

--- a/src/Abbot.CommandLine/Services/ApiClientFactory.cs
+++ b/src/Abbot.CommandLine/Services/ApiClientFactory.cs
@@ -1,0 +1,29 @@
+using Refit;
+using Serious.Abbot.CommandLine.Commands;
+
+namespace Serious.Abbot.CommandLine.Services
+{
+    public class ApiClientFactory : IApiClientFactory
+    {
+#if DEBUG
+        const string ApiHost = "https://localhost:4979/";
+#else
+        const string ApiHost = "https://api.ab.bot/";
+#endif
+
+        public IAbbotApi Create(Workspace workspace)
+        {
+            var settings = new RefitSettings
+            {
+                AuthorizationHeaderValueGetter = async () => await workspace.GetTokenAsync() ?? string.Empty,
+            };
+#pragma warning disable CA2000
+            var httpClient = RestService.CreateHttpClient(ApiHost, settings);
+#pragma warning restore CA2000
+            var version = StatusCommand.GetVersion();
+            httpClient.DefaultRequestHeaders.Add("X-Client-Version", version);
+            httpClient.DefaultRequestHeaders.Add("User-Agent", $"abbot-cli ({version})");
+            return RestService.For<IAbbotApi>(httpClient);
+        }
+    }
+}

--- a/src/Abbot.CommandLine/Services/IApiClientFactory.cs
+++ b/src/Abbot.CommandLine/Services/IApiClientFactory.cs
@@ -1,0 +1,14 @@
+namespace Serious.Abbot.CommandLine.Services
+{
+    /// <summary>
+    /// Used to create Abbot API clients.
+    /// </summary>
+    public interface IApiClientFactory
+    {
+        /// <summary>
+        /// Creates the Abbot API client using the API token stored in the workspace.
+        /// </summary>
+        /// <param name="workspace">The workspace</param>
+        IAbbotApi Create(Workspace workspace);
+    }
+}

--- a/src/Abbot.CommandLine/Services/SkillWorkspace.cs
+++ b/src/Abbot.CommandLine/Services/SkillWorkspace.cs
@@ -128,18 +128,11 @@ namespace Serious.Abbot.CommandLine.Services
         /// <summary>
         /// Used to retrieve the code for the skill. This is used when running or deploying the code.
         /// </summary>
-        /// <param name="workspace">The Abbot Workspace.</param>
-        public async Task<CodeResult> GetCodeAsync(Workspace workspace)
+        public async Task<CodeResult> GetCodeAsync()
         {
-            if (!workspace.IsInitialized)
-            {
-                var directoryType = workspace.DirectorySpecified ? "specified" : "current";
-                return CodeResult.Fail($"The {directoryType} directory is not an Abbot Workspace. Either specify the path to an Abbot Workspace, or initialize a new one using `abbot init`");
-            }
-            
             if (!Exists)
             {
-                return CodeResult.Fail($"The directory {WorkingDirectory} does not exist. Have you run `abbot get {SkillName}` yet?");
+                return CodeResult.Fail($"The skill directory {WorkingDirectory} does not exist. Have you run `abbot get {SkillName}` yet? Or use the `--deployed` flag to run the deployed version of this skill on the server.");
             }
 
             var codeFile = await GetCodeFile();

--- a/tests/UnitTests/Commands/ReplCommandTests.cs
+++ b/tests/UnitTests/Commands/ReplCommandTests.cs
@@ -1,0 +1,39 @@
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+using Serious.Abbot.CommandLine.Commands;
+using UnitTests.Fakes;
+using Xunit;
+
+public class ReplCommandTests
+{
+    [Fact]
+    public async Task ReportsErrorWhenNotWorkspace()
+    {
+        var context = new FakeCommandContext();
+        var command = new ReplCommand(context, new RunCommand(context));
+        var parseResult = command.Parse("repl test \"some args\" -d ./my-skills");
+
+        var result = await command.Handler!.InvokeAsync(new InvocationContext(parseResult, context.FakeConsole));
+        
+        Assert.Equal(1, result);
+        var error = context.FakeConsole.Error.ToString();
+        Assert.Equal("The specified directory is not an Abbot Workspace. Either specify the path to an Abbot Workspace, or initialize a new one using `abbot init`\n", error);
+    }
+    
+    [Fact]
+    public async Task ReportsWhenSkillDirectoryDoesNotExist()
+    {
+        var context = new FakeCommandContext();
+        var command = new ReplCommand(context, new RunCommand(context));
+        var workspace = context.GetWorkspace("./my-skills");
+        await workspace.EnsureAsync();
+        var parseResult = command.Parse("repl test \"some args\" -d ./my-skills");
+
+        var result = await command.Handler!.InvokeAsync(new InvocationContext(parseResult, context.FakeConsole));
+        
+        Assert.Equal(1, result);
+        var error = context.FakeConsole.Error.ToString();
+        Assert.Equal("The skill directory ./my-skills/test does not exist. Have you run `abbot get test` yet? Or use the `--deployed` flag to run the deployed version of this skill on the server.\n", error);
+    }    
+}

--- a/tests/UnitTests/Commands/RunCommandTests.cs
+++ b/tests/UnitTests/Commands/RunCommandTests.cs
@@ -1,0 +1,79 @@
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+using Serious.Abbot.CommandLine.Commands;
+using Serious.Abbot.Messages;
+using UnitTests.Fakes;
+using Xunit;
+
+public class RunCommandTests
+{
+    [Fact]
+    public async Task ReportsErrorWhenNotWorkspace()
+    {
+        var context = new FakeCommandContext();
+        var command = new RunCommand(context);
+        var parseResult = command.Parse("run test \"some args\" -d ./my-skills");
+
+        var result = await command.Handler!.InvokeAsync(new InvocationContext(parseResult, context.FakeConsole));
+        
+        Assert.Equal(1, result);
+        var error = context.FakeConsole.Error.ToString();
+        Assert.Equal("The specified directory is not an Abbot Workspace. Either specify the path to an Abbot Workspace, or initialize a new one using `abbot init`\n", error);
+    }
+    
+    [Fact]
+    public async Task ReportsWhenSkillDirectoryDoesNotExist()
+    {
+        var context = new FakeCommandContext();
+        var command = new RunCommand(context);
+        var workspace = context.GetWorkspace("./my-skills");
+        await workspace.EnsureAsync();
+        var parseResult = command.Parse("run test \"some args\" -d ./my-skills");
+
+        var result = await command.Handler!.InvokeAsync(new InvocationContext(parseResult, context.FakeConsole));
+        
+        Assert.Equal(1, result);
+        var error = context.FakeConsole.Error.ToString();
+        Assert.Equal("The skill directory ./my-skills/test does not exist. Have you run `abbot get test` yet? Or use the `--deployed` flag to run the deployed version of this skill on the server.\n", error);
+    }
+    
+    [Fact]
+    public async Task RunsLocalSkill()
+    {
+        var context = new FakeCommandContext();
+        var command = new RunCommand(context);
+        var workspace = context.GetWorkspace("./my-skills");
+        await workspace.EnsureAsync();
+        var apiClient = context.CreateApiClient(workspace) as FakeApiClient;
+        apiClient!.AddResponse("test", new SkillRunResponse { Replies = new List<string> {"Hello, World!"}});
+        var skillWorkspace = workspace.GetSkillWorkspace("test");
+        await skillWorkspace.CreateAsync(new SkillGetResponse { Name = "test", Code = "// Code" });
+        var parseResult = command.Parse("run test \"some args\" -d ./my-skills");
+
+        var result = await command.Handler!.InvokeAsync(new InvocationContext(parseResult, context.FakeConsole));
+        
+        Assert.Equal(0, result);
+        var output = context.FakeConsole.Out.ToString();
+        Assert.Equal("Hello, World!\n", output);
+    }
+    
+    [Fact]
+    public async Task RunsDeployedSkillEvenWhenLocalDoesNotExist()
+    {
+        var context = new FakeCommandContext();
+        var command = new RunCommand(context);
+        var workspace = context.GetWorkspace("./my-skills");
+        await workspace.EnsureAsync();
+        var apiClient = context.CreateApiClient(workspace) as FakeApiClient;
+        apiClient!.AddResponse("test", new SkillRunResponse { Replies = new List<string> {"Hello, World!"}});
+        var parseResult = command.Parse("run test \"some args\" -d ./my-skills -s");
+
+        var result = await command.Handler!.InvokeAsync(new InvocationContext(parseResult, context.FakeConsole));
+        
+        Assert.Equal(0, result);
+        var output = context.FakeConsole.Out.ToString();
+        Assert.Equal("Hello, World!\n", output);
+    }
+}

--- a/tests/UnitTests/DictionaryExtensions.cs
+++ b/tests/UnitTests/DictionaryExtensions.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+
+namespace UnitTests
+{
+    public static class DictionaryExtensions
+    {
+        public static TValue GetOrCreate<TKey, TValue>(
+            this IDictionary<TKey, TValue> dictionary, TKey key,
+            Func<TKey, TValue> creator)
+        {
+            if (!dictionary.TryGetValue(key, out var value))
+            {
+                value = creator(key);
+                dictionary.Add(key, value);
+            }
+
+            return value;
+        }
+    }
+}

--- a/tests/UnitTests/Fakes/FakeApiClient.cs
+++ b/tests/UnitTests/Fakes/FakeApiClient.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Refit;
+using Serious.Abbot.CommandLine;
+using Serious.Abbot.Messages;
+
+namespace UnitTests.Fakes
+{
+    public class FakeApiClient : IAbbotApi
+    {
+        readonly Dictionary<Type, Dictionary<string, IApiResponse>> _skillApiResponses = new()
+        {
+            {typeof(SkillGetResponse), new Dictionary<string, IApiResponse>()},
+            {typeof(SkillRunResponse), new Dictionary<string, IApiResponse>()},
+            {typeof(SkillUpdateResponse), new Dictionary<string, IApiResponse>()}
+        };
+        
+        readonly Dictionary<Type, IApiResponse> _apiResponses = new();
+
+        
+        public void AddResponse<T>(IApiResponse<T> response)
+        {
+            _apiResponses.Add(typeof(T), response);
+        }
+        
+        public void AddResponse<T>(T responseBody)
+        {
+            IApiResponse<T> response = new ApiResponse<T>(new HttpResponseMessage(HttpStatusCode.OK), responseBody, new RefitSettings(), null);
+            _apiResponses.Add(typeof(T), response);
+        }
+
+        public void AddResponse<T>(string skill, IApiResponse<T> response)
+        {
+            _skillApiResponses[typeof(T)].Add(skill, response);
+        }
+
+        public void AddResponse<T>(string skill, T responseBody)
+        {
+            IApiResponse<T> response = new ApiResponse<T>(new HttpResponseMessage(HttpStatusCode.OK), responseBody, new RefitSettings(), null);
+            AddResponse(skill, response);
+        }
+
+        public Task<ApiResponse<SkillGetResponse>> GetSkillAsync(string skill)
+        {
+            return GetResponse<SkillGetResponse>(skill);
+        }
+
+        public Task<ApiResponse<StatusGetResponse>> GetStatusAsync()
+        {
+            return GetResponse<StatusGetResponse>();
+        }
+        
+        public Task<ApiResponse<SkillUpdateResponse>> DeploySkillAsync(string skill, SkillUpdateRequest updateRequest)
+        {
+            return GetResponse<SkillUpdateResponse>(skill);
+        }
+
+        public Task<ApiResponse<SkillRunResponse>> RunSkillAsync(string skill, SkillRunRequest runRequest)
+        {
+            return GetResponse<SkillRunResponse>(skill);
+        }
+
+        public Task<ApiResponse<SkillRunResponse>> RunDeployedSkillAsync(string skill, SkillRunRequest runRequest)
+        {
+            return GetResponse<SkillRunResponse>(skill);
+        }
+
+        public Task<ApiResponse<SkillListResponse>> ListSkillsAsync(SkillOrderBy orderBy, OrderDirection direction, bool includeDisable = false)
+        {
+            return GetResponse<SkillListResponse>();
+        }
+
+        Task<ApiResponse<T>> GetResponse<T>(string skill)
+        {
+            var responses = _skillApiResponses[typeof(T)];
+            
+            var response = responses.TryGetValue(skill, out var found)
+                ? found
+                : new ApiResponse<T>(new HttpResponseMessage(HttpStatusCode.NotFound), default(T), new RefitSettings(), null);
+            return Task.FromResult((ApiResponse<T>)response);
+        }
+        
+        Task<ApiResponse<T>> GetResponse<T>()
+        {
+            var response = _apiResponses.TryGetValue(typeof(T), out var found)
+                ? found
+                : new ApiResponse<T>(new HttpResponseMessage(HttpStatusCode.NotFound), default(T), new RefitSettings(), null);
+            return Task.FromResult((ApiResponse<T>)response);
+        }
+    }
+}

--- a/tests/UnitTests/Fakes/FakeApiClientFactory.cs
+++ b/tests/UnitTests/Fakes/FakeApiClientFactory.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Serious.Abbot.CommandLine;
+using Serious.Abbot.CommandLine.Services;
+
+namespace UnitTests.Fakes
+{
+    public class FakeApiClientFactory : IApiClientFactory
+    {
+        readonly Dictionary<string, IAbbotApi> _clients = new();
+        public IAbbotApi Create(Workspace workspace)
+        {
+            return _clients.GetOrCreate(workspace.WorkingDirectory.FullName, _ => new FakeApiClient());
+        }
+    }
+}

--- a/tests/UnitTests/Fakes/FakeCommandContext.cs
+++ b/tests/UnitTests/Fakes/FakeCommandContext.cs
@@ -1,0 +1,32 @@
+using Serious.Abbot.CommandLine;
+using Serious.Abbot.CommandLine.Services;
+
+namespace UnitTests.Fakes
+{
+    public class FakeCommandContext : CommandContext
+    {
+        readonly FakeApiClientFactory _fakeApiClientFactory;
+        
+        public FakeCommandContext()
+            : this(new FakeConsole(), new FakeWorkspaceFactory(), new FakeApiClientFactory())
+        {
+        }
+
+        FakeCommandContext(
+            FakeConsole console,
+            IWorkspaceFactory workspaceFactory,
+            FakeApiClientFactory apiClientFactory)
+            : base(
+                console,
+                workspaceFactory,
+                apiClientFactory)
+        {
+            FakeConsole = console;
+            _fakeApiClientFactory = apiClientFactory;
+        }
+        
+        public FakeConsole FakeConsole { get; }
+
+        public FakeApiClient GetFakeApiClient(Workspace workspace) => (_fakeApiClientFactory.Create(workspace) as FakeApiClient)!;
+    }
+}

--- a/tests/UnitTests/Fakes/FakeConsole.cs
+++ b/tests/UnitTests/Fakes/FakeConsole.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections.Generic;
+using System.CommandLine.IO;
+using Serious.Abbot.CommandLine.IO;
+
+namespace UnitTests.Fakes
+{
+    public class FakeConsole : TestConsole, IExtendedConsole
+    {
+        readonly Queue<string> _lines = new();
+        readonly Queue<ConsoleKeyInfo> _chars = new();
+
+        public void PushLine(string line) => _lines.Enqueue(line);
+
+        public void PushKey(char key) => _chars.Enqueue(new ConsoleKeyInfo(key, 0, false, false, false));
+
+        public void Clear() => Console.Clear();
+        public string? ReadLine() => _lines.Dequeue();
+
+        public int Read() => _chars.Dequeue().KeyChar;
+
+        public ConsoleKeyInfo ReadKey() => _chars.Dequeue();
+
+        public ConsoleKeyInfo ReadKey(bool intercept) => _chars.Dequeue();
+    }
+}

--- a/tests/UnitTests/Fakes/FakeWorkspaceFactory.cs
+++ b/tests/UnitTests/Fakes/FakeWorkspaceFactory.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Serious.Abbot.CommandLine.Services;
+
+namespace UnitTests.Fakes
+{
+    public class FakeWorkspaceFactory : IWorkspaceFactory
+    {
+        readonly Dictionary<string, Workspace> _workspaces = new();
+        
+        public Workspace GetWorkspace(string? directory)
+        {
+            return _workspaces.GetOrCreate(
+                directory ?? ".",
+                dir => new Workspace(new FakeDirectoryInfo(dir ?? "."), dir is not null));
+        }
+    }
+}

--- a/tests/UnitTests/Services/SkillWorkspaceTests.cs
+++ b/tests/UnitTests/Services/SkillWorkspaceTests.cs
@@ -126,7 +126,7 @@ public class SkillWorkspaceTests
             };
             await skillWorkspace.CreateAsync(response);
 
-            var codeResult = await skillWorkspace.GetCodeAsync(workspace);
+            var codeResult = await skillWorkspace.GetCodeAsync();
             
             Assert.True(codeResult.IsSuccess);
             Assert.Equal("# This is the code", codeResult.Code);
@@ -150,28 +150,12 @@ public class SkillWorkspaceTests
             };
             await skillWorkspace.CreateAsync(response);
 
-            var codeResult = await skillWorkspace.GetCodeAsync(workspace);
+            var codeResult = await skillWorkspace.GetCodeAsync();
             
             Assert.True(codeResult.IsSuccess);
             Assert.Equal("# This is the code", codeResult.Code);
         }
 
-        [Theory]
-        [InlineData(true, "specified")]
-        [InlineData(false, "current")]
-        public async Task ReportsErrorWhenWorkspaceDirectoryDoesNotExist(bool directorySpecified, string expectedType)
-        {
-            var directory = new FakeDirectoryInfo("./skills");
-            var workspace = new Workspace(directory, directorySpecified);
-            var skillWorkspace = new SkillWorkspace(directory.GetSubdirectory("my-skill"));
-            
-            var codeResult = await skillWorkspace.GetCodeAsync(workspace);
-            
-            Assert.False(codeResult.IsSuccess);
-            Assert.Null(codeResult.Code);
-            Assert.Equal($"The {expectedType} directory is not an Abbot Workspace. Either specify the path to an Abbot Workspace, or initialize a new one using `abbot init`", codeResult.ErrorMessage);
-        }
-        
         [Fact]
         public async Task ReportsErrorWhenSkillDirectoryDoesNotExist()
         {
@@ -180,11 +164,11 @@ public class SkillWorkspaceTests
             await workspace.EnsureAsync();
             var skillWorkspace = new SkillWorkspace(directory.GetSubdirectory("my-skill"));
             
-            var codeResult = await skillWorkspace.GetCodeAsync(workspace);
+            var codeResult = await skillWorkspace.GetCodeAsync();
             
             Assert.False(codeResult.IsSuccess);
             Assert.Null(codeResult.Code);
-            Assert.Equal("The directory ./skills/my-skill does not exist. Have you run `abbot get my-skill` yet?", codeResult.ErrorMessage);
+            Assert.Equal("The skill directory ./skills/my-skill does not exist. Have you run `abbot get my-skill` yet? Or use the `--deployed` flag to run the deployed version of this skill on the server.", codeResult.ErrorMessage);
         }
         
         [Fact]
@@ -197,7 +181,7 @@ public class SkillWorkspaceTests
             var skillWorkspace = new SkillWorkspace(skillDirectory);
             skillDirectory.Create();
             
-            var codeResult = await skillWorkspace.GetCodeAsync(workspace);
+            var codeResult = await skillWorkspace.GetCodeAsync();
             
             Assert.False(codeResult.IsSuccess);
             Assert.Null(codeResult.Code);


### PR DESCRIPTION
This adds the `--deployed` flag to the `run` and `repl` skills. This allows the user to run the deployed version of the skill (as opposed to the local version). It allows them to run the skill even if the skill hasn't been downloaded locally.

Fixes #10